### PR TITLE
fix: add missing search content page

### DIFF
--- a/content/search/_index.md
+++ b/content/search/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Search"
+layout: "search"
+sitemap:
+    priority: 0.1
+---


### PR DESCRIPTION
## Summary
- add `content/search/_index.md` so `/search/` resolves to the existing `search` layout
- keep the change minimal and scoped to the template content route

## Why
New user-group sites created from this template should include a working `/search/` page by default.

Related:
- India site PR: https://github.com/qgis/QGIS-UG-India/pull/82
- Theme PR: https://github.com/qgis/QGIS-Hugo-Website-Theme/pull/5